### PR TITLE
chore: Update @biomejs/biome to version 2.4.5 for improved compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "pino-zen": "lib/pino-zen-cli.js"
             },
             "devDependencies": {
-                "@biomejs/biome": "^2.4.4",
+                "@biomejs/biome": "^2.4.5",
                 "@types/node": "^25.x.x",
                 "@types/split2": "^4.2.3",
                 "typescript": "^5.9.3"
@@ -28,9 +28,9 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.4.tgz",
-            "integrity": "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.5.tgz",
+            "integrity": "sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -44,20 +44,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.4.4",
-                "@biomejs/cli-darwin-x64": "2.4.4",
-                "@biomejs/cli-linux-arm64": "2.4.4",
-                "@biomejs/cli-linux-arm64-musl": "2.4.4",
-                "@biomejs/cli-linux-x64": "2.4.4",
-                "@biomejs/cli-linux-x64-musl": "2.4.4",
-                "@biomejs/cli-win32-arm64": "2.4.4",
-                "@biomejs/cli-win32-x64": "2.4.4"
+                "@biomejs/cli-darwin-arm64": "2.4.5",
+                "@biomejs/cli-darwin-x64": "2.4.5",
+                "@biomejs/cli-linux-arm64": "2.4.5",
+                "@biomejs/cli-linux-arm64-musl": "2.4.5",
+                "@biomejs/cli-linux-x64": "2.4.5",
+                "@biomejs/cli-linux-x64-musl": "2.4.5",
+                "@biomejs/cli-win32-arm64": "2.4.5",
+                "@biomejs/cli-win32-x64": "2.4.5"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.4.tgz",
-            "integrity": "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.5.tgz",
+            "integrity": "sha512-lGS4Nd5O3KQJ6TeWv10mElnx1phERhBxqGP/IKq0SvZl78kcWDFMaTtVK+w3v3lusRFxJY78n07PbKplirsU5g==",
             "cpu": [
                 "arm64"
             ],
@@ -72,9 +72,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.4.tgz",
-            "integrity": "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.5.tgz",
+            "integrity": "sha512-6MoH4tyISIBNkZ2Q5T1R7dLd5BsITb2yhhhrU9jHZxnNSNMWl+s2Mxu7NBF8Y3a7JJcqq9nsk8i637z4gqkJxQ==",
             "cpu": [
                 "x64"
             ],
@@ -89,9 +89,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.4.tgz",
-            "integrity": "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.5.tgz",
+            "integrity": "sha512-U1GAG6FTjhAO04MyH4xn23wRNBkT6H7NentHh+8UxD6ShXKBm5SY4RedKJzkUThANxb9rUKIPc7B8ew9Xo/cWg==",
             "cpu": [
                 "arm64"
             ],
@@ -106,9 +106,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.4.tgz",
-            "integrity": "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.5.tgz",
+            "integrity": "sha512-iqLDgpzobG7gpBF0fwEVS/LT8kmN7+S0E2YKFDtqliJfzNLnAiV2Nnyb+ehCDCJgAZBASkYHR2o60VQWikpqIg==",
             "cpu": [
                 "arm64"
             ],
@@ -123,9 +123,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz",
-            "integrity": "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.5.tgz",
+            "integrity": "sha512-NdODlSugMzTlENPTa4z0xB82dTUlCpsrOxc43///aNkTLblIYH4XpYflBbf5ySlQuP8AA4AZd1qXhV07IdrHdQ==",
             "cpu": [
                 "x64"
             ],
@@ -140,9 +140,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.4.tgz",
-            "integrity": "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.5.tgz",
+            "integrity": "sha512-NlKa7GpbQmNhZf9kakQeddqZyT7itN7jjWdakELeXyTU3pg/83fTysRRDPJD0akTfKDl6vZYNT9Zqn4MYZVBOA==",
             "cpu": [
                 "x64"
             ],
@@ -157,9 +157,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.4.tgz",
-            "integrity": "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.5.tgz",
+            "integrity": "sha512-EBfrTqRIWOFSd7CQb/0ttjHMR88zm3hGravnDwUA9wHAaCAYsULKDebWcN5RmrEo1KBtl/gDVJMrFjNR0pdGUw==",
             "cpu": [
                 "arm64"
             ],
@@ -174,9 +174,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz",
-            "integrity": "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.5.tgz",
+            "integrity": "sha512-Pmhv9zT95YzECfjEHNl3mN9Vhusw9VA5KHY0ZvlGsxsjwS5cb7vpRnHzJIv0vG7jB0JI7xEaMH9ddfZm/RozBw==",
             "cpu": [
                 "x64"
             ],
@@ -281,74 +281,74 @@
     },
     "dependencies": {
         "@biomejs/biome": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.4.tgz",
-            "integrity": "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.5.tgz",
+            "integrity": "sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ==",
             "dev": true,
             "requires": {
-                "@biomejs/cli-darwin-arm64": "2.4.4",
-                "@biomejs/cli-darwin-x64": "2.4.4",
-                "@biomejs/cli-linux-arm64": "2.4.4",
-                "@biomejs/cli-linux-arm64-musl": "2.4.4",
-                "@biomejs/cli-linux-x64": "2.4.4",
-                "@biomejs/cli-linux-x64-musl": "2.4.4",
-                "@biomejs/cli-win32-arm64": "2.4.4",
-                "@biomejs/cli-win32-x64": "2.4.4"
+                "@biomejs/cli-darwin-arm64": "2.4.5",
+                "@biomejs/cli-darwin-x64": "2.4.5",
+                "@biomejs/cli-linux-arm64": "2.4.5",
+                "@biomejs/cli-linux-arm64-musl": "2.4.5",
+                "@biomejs/cli-linux-x64": "2.4.5",
+                "@biomejs/cli-linux-x64-musl": "2.4.5",
+                "@biomejs/cli-win32-arm64": "2.4.5",
+                "@biomejs/cli-win32-x64": "2.4.5"
             }
         },
         "@biomejs/cli-darwin-arm64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.4.tgz",
-            "integrity": "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.5.tgz",
+            "integrity": "sha512-lGS4Nd5O3KQJ6TeWv10mElnx1phERhBxqGP/IKq0SvZl78kcWDFMaTtVK+w3v3lusRFxJY78n07PbKplirsU5g==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-darwin-x64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.4.tgz",
-            "integrity": "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.5.tgz",
+            "integrity": "sha512-6MoH4tyISIBNkZ2Q5T1R7dLd5BsITb2yhhhrU9jHZxnNSNMWl+s2Mxu7NBF8Y3a7JJcqq9nsk8i637z4gqkJxQ==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-linux-arm64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.4.tgz",
-            "integrity": "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.5.tgz",
+            "integrity": "sha512-U1GAG6FTjhAO04MyH4xn23wRNBkT6H7NentHh+8UxD6ShXKBm5SY4RedKJzkUThANxb9rUKIPc7B8ew9Xo/cWg==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-linux-arm64-musl": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.4.tgz",
-            "integrity": "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.5.tgz",
+            "integrity": "sha512-iqLDgpzobG7gpBF0fwEVS/LT8kmN7+S0E2YKFDtqliJfzNLnAiV2Nnyb+ehCDCJgAZBASkYHR2o60VQWikpqIg==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-linux-x64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz",
-            "integrity": "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.5.tgz",
+            "integrity": "sha512-NdODlSugMzTlENPTa4z0xB82dTUlCpsrOxc43///aNkTLblIYH4XpYflBbf5ySlQuP8AA4AZd1qXhV07IdrHdQ==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-linux-x64-musl": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.4.tgz",
-            "integrity": "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.5.tgz",
+            "integrity": "sha512-NlKa7GpbQmNhZf9kakQeddqZyT7itN7jjWdakELeXyTU3pg/83fTysRRDPJD0akTfKDl6vZYNT9Zqn4MYZVBOA==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-win32-arm64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.4.tgz",
-            "integrity": "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.5.tgz",
+            "integrity": "sha512-EBfrTqRIWOFSd7CQb/0ttjHMR88zm3hGravnDwUA9wHAaCAYsULKDebWcN5RmrEo1KBtl/gDVJMrFjNR0pdGUw==",
             "dev": true,
             "optional": true
         },
         "@biomejs/cli-win32-x64": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz",
-            "integrity": "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.5.tgz",
+            "integrity": "sha512-Pmhv9zT95YzECfjEHNl3mN9Vhusw9VA5KHY0ZvlGsxsjwS5cb7vpRnHzJIv0vG7jB0JI7xEaMH9ddfZm/RozBw==",
             "dev": true,
             "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "split2": "^4.2.0"
     },
     "devDependencies": {
-        "@biomejs/biome": "^2.4.4",
+        "@biomejs/biome": "^2.4.5",
         "@types/node": "^25.x.x",
         "@types/split2": "^4.2.3",
         "typescript": "^5.9.3"


### PR DESCRIPTION
This pull request includes a minor update to the `@biomejs/biome` development dependency in the `package.json` file. The version has been bumped from `2.4.4` to `2.4.5`, ensuring the project uses the latest bug fixes and improvements for this tool.